### PR TITLE
removed chown to www-data since chaning the symlink ownership changes…

### DIFF
--- a/tasks/config_apache2_symlinks.yml
+++ b/tasks/config_apache2_symlinks.yml
@@ -3,8 +3,6 @@
   file:
     src: "{{ apt_mirror_dir }}/mirror/{{ item['uri'] }}"
     dest: "{{ apache2_default_root }}/{{ item['distro'] }}"
-    owner: www-data
-    group: www-data
     state: link
     force: yes  #we do this because the src may/may not exist yet
   become: true


### PR DESCRIPTION
… the targets permissions.

in this case it changes the original apt-mirror directories that in turn creates errors for apt-mirror since the directories are no longer owned by user apt-mirror