### PR TITLE
Fixed a deprecated error that include has been removed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
 # tasks file for ansible-apt-mirror
-- include: debian.yml
+- include_tasks: debian.yml
   when:
     - ansible_os_family == "Debian"
     - apt_mirror_client is defined
     - not apt_mirror_client|bool
 
-- include: config_apt_mirror.yml
+- include_tasks: config_apt_mirror.yml
   when:
     - ansible_os_family == "Debian"
     - apt_mirror_client is defined
     - not apt_mirror_client|bool
 
-- include: config_apt_mirror_client.yml
+- include_tasks: config_apt_mirror_client.yml
   when:
     - ansible_os_family == "Debian"
     - apt_mirror_client is defined
     - apt_mirror_client|bool
 
-- include: config_apt_mirror_schedule.yml
+- include_tasks: config_apt_mirror_schedule.yml
   when:
     - ansible_os_family == "Debian"
     - apt_mirror_client is defined
@@ -26,7 +26,7 @@
     - apt_mirror_schedule_updates is defined
     - apt_mirror_schedule_updates|bool
 
-- include: config_apache2_symlinks.yml
+- include_tasks: config_apache2_symlinks.yml
   when:
     - ansible_os_family == "Debian"
     - apt_mirror_client is defined


### PR DESCRIPTION
Fixed a deprecated error that include has been removed.

## Description
I ran it with the latest Ansible and got the following error:
```
PLAY [repo] **********************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
ok: [repo-01]
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```
Presumably include was deprecated in Ansible 2.12 and removed in Ansible 2.16.

My Ansible version is as follows:
```
$ ansible --version
ansible [core 2.16.3]
  config file = None
  configured module search path = ['/home/ubuntu/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/venv-ansible/lib/python3.10/site-packages/ansible
  ansible collection location = /home/ubuntu/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/ubuntu/venv-ansible/bin/ansible
  python version = 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] (/home/ubuntu/venv-ansible/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```

## Related Issue
No related issue

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
